### PR TITLE
build: bump to Go 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/x-way/vtysock
 
-go 1.24.6
+go 1.27.0


### PR DESCRIPTION
Bump the go.mod language version to Go 1.27.