### PR TITLE
build: use golangci-lint v2 module path to pick up Go 1.27 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 
 lint:
 	go vet -v ./...
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	golangci-lint run
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	staticcheck -checks all ./...

--- a/vtysock.go
+++ b/vtysock.go
@@ -65,7 +65,7 @@ func runCmd(socketPath string, cmd string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer socket.Close()
+	defer func() { _ = socket.Close() }()
 
 	cmd = cmd + "\x00"
 	_, err = socket.Write([]byte(cmd))


### PR DESCRIPTION
Swap the golangci-lint install path to /v2 so `make lint` picks up a release built with Go 1.27 (the pinned v1.x binary predates 1.27 support). Also fixes a new errcheck finding surfaced by the newer linter's default rule set.